### PR TITLE
fix(controls): remove distinctUntilChanged() in control events

### DIFF
--- a/src/ui/controls/PlaybackButtons.js
+++ b/src/ui/controls/PlaybackButtons.js
@@ -19,7 +19,7 @@ export default ({audio, DOM}) => {
   const audio$ = Observable.merge(
     DOM.select('.ctrl-play').events('click').map({type: 'PLAY'}),
     DOM.select('.ctrl-pause').events('click').map({type: 'PAUSE'})
-  ).distinctUntilChanged()
+  )
   return {
     audio$, DOM: Observable.merge(playPause$, loadStart$).map(x => div(x))
   }


### PR DESCRIPTION
using distinctUntilChanged() ignores all pause commands after a song is paused and another one is
played.

fixes #24