### PR TITLE
fix(search): use flatMapLatest to show results of the latest request …

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cycle-snabbdom": "^1.2.1",
     "express": "^4.13.4",
     "file-loader": "^0.8.5",
+    "funjector": "^3.1.0",
     "handlebars": "^4.0.5",
     "handlebars-loader": "^1.2.0",
     "html-webpack-plugin": "^2.16.0",

--- a/src/Utils/SoundCloud.js
+++ b/src/Utils/SoundCloud.js
@@ -5,6 +5,7 @@
 'use strict'
 
 import qs from 'qs'
+import {partial} from 'funjector'
 
 const CLIENT_ID = '1862b9bf02ed7c80d0f545f835ad8773'
 const baseURL = 'https://api.soundcloud.com'
@@ -17,11 +18,11 @@ export const get = (path, params) => {
   return fetch(`${baseURL}${path}${clientIDParams(params)}`).then(x => x.json())
 }
 
-export const searchTracks = q$ => {
-  return q$.debounce(500)
-    .flatMap(q => get('/tracks', {q}))
-    .share()
-}
+export const searchTracks = partial(
+  (get, q$) => q$
+    .flatMapLatest(q => get('/tracks', {q}))
+    .share(),
+  get)
 
 export const durationFormat = time => {
   const mins = Math.floor(time / 60000)

--- a/src/ui/App.js
+++ b/src/ui/App.js
@@ -14,7 +14,7 @@ import * as SC from '../Utils/SoundCloud'
 
 export default function ({DOM, route, audio}) {
   const searchBox = SearchBox({DOM, route})
-  const tracks$ = SC.searchTracks(searchBox.value$)
+  const tracks$ = SC.searchTracks(searchBox.value$.debounce(300))
   const playlist = Playlist({tracks$, DOM, audio})
   const selectedTrack$ = playlist.selectedTrack$
 

--- a/test/test.SoundCloud.js
+++ b/test/test.SoundCloud.js
@@ -5,10 +5,28 @@
 'use strict'
 
 import test from 'ava'
+import {orig} from 'funjector'
+import {ReactiveTest, TestScheduler, Observable} from 'rx'
 import * as SC from '../src/Utils/SoundCloud'
+const {onNext, onCompleted} = ReactiveTest
 
-test(t => {
+test('durationFormat()', t => {
   t.is(SC.durationFormat(5000), '0:50')
   t.is(SC.durationFormat(60000), '1:00')
   t.is(SC.durationFormat(645000), '10:45')
+})
+
+test('searchTracks()', t => {
+  const searchTracks = orig(SC.searchTracks)
+  const sh = new TestScheduler()
+
+  const get = (_, {q}) => Observable.just(q).delay(q * 100, sh)
+
+  const q$ = sh.createHotObservable(
+    onNext(210, 5),
+    onNext(220, 1)
+  )
+
+  const {messages} = sh.startScheduler(() => searchTracks(get, q$))
+  t.deepEqual(messages, [onNext(320, 1)])
 })


### PR DESCRIPTION
…that was made

request should ideally be cancelled by with flatMapLatest the user will always receive the response
of the latest result thus maintaining the order.