### PR TITLE
fix(lib): apply preventDefault() on doubleclick

### DIFF
--- a/src/lib/DoubleClick.js
+++ b/src/lib/DoubleClick.js
@@ -9,4 +9,4 @@ export default (element, timeout = 600, sh) => element
   .timeInterval(sh)
   .bufferWithCount(2)
   .filter(([a, b]) => b.interval < timeout)
-  .map(([a, b]) => [a.value, b.value])
+  .map(([a, b]) => [a.value.preventDefault(), b.value.preventDefault()])


### PR DESCRIPTION
without doubleclik the default behaviour is to zoom in/out